### PR TITLE
Fixed - imgName in this.events array

### DIFF
--- a/03-Expressions&Filters/04-BuiltInFilters/app/event/eventModule.js
+++ b/03-Expressions&Filters/04-BuiltInFilters/app/event/eventModule.js
@@ -92,7 +92,7 @@ angular.module('eventModule', [])
 		title: "London",
 		itemTitle:mainTitle.title,
 		description:" is a one day event that teaches kids how to code",
-		imgName:"London",
+		imgName:"london",
 		date:Date.parse("September 26 2015")
 	},
 


### PR DESCRIPTION
The imgName for object with title **London** should be **london** so that we can get src="assets/img/london_small.jpg" which resulted in ENOENT. **London** was used there which caused the error.